### PR TITLE
not rendering rating for unrated films

### DIFF
--- a/src/components/Thumbnail/Thumbnail.tsx
+++ b/src/components/Thumbnail/Thumbnail.tsx
@@ -47,7 +47,7 @@ const RecommendedTitle: React.FC<{ movie: iMovie }> = ({ movie }) => {
       </div>
       <div className={classes.secondRow}>
         <div>{movie.year}</div>
-        <div>{movie.rating} rating</div>
+        {movie.rating === 'Not Rated' ? null : <div>{movie.rating} rating</div>}
       </div>
     </div>
   );


### PR DESCRIPTION
## Länkat issue
[Thumbnails går sönder på filmer utan rating](https://github.com/JNMTFFED22G/Filmflix/issues/29)

## Problem / Mål
Filmer som saknar rating ska inte presentera någon rating i sin thumbnail.

## Utredning
Antog först att alla filmer var tvungna att ha en rating, men vissa har "Not Rated" som rating. Denna rating ska självklart in renderas ut.

## Lösning / Implementation
- Villkorlig rendering för rating-fältet.

## Testning
En användare ska ej se klassificeringen(?) för icke rated filmer. (hm, skum svengelska ;P )
