### PR TITLE
36 show age rating and year on all thumbnails

### DIFF
--- a/src/components/Thumbnail/Thumbnail.tsx
+++ b/src/components/Thumbnail/Thumbnail.tsx
@@ -42,7 +42,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({ movie }) => {
   return (
     <>
       <div className={classes.outerDiv}>
-      <MovieTitle movie={movie} />
+        <MovieTitle movie={movie} />
         <Link to={movie.slug}>
           <img
             className={classes.image}

--- a/src/components/Thumbnail/Thumbnail.tsx
+++ b/src/components/Thumbnail/Thumbnail.tsx
@@ -32,6 +32,10 @@ const MovieTitle: React.FC<TitleProps> = ({ movie }) => {
   );
 };
 
+interface ThumbnailProps {
+  movie: iMovie;
+}
+
 const Thumbnail: React.FC<ThumbnailProps> = ({ movie }) => {
   const [imgSrc, setImgSrc] = useState(movie.thumbnail);
 

--- a/src/components/Thumbnail/Thumbnail.tsx
+++ b/src/components/Thumbnail/Thumbnail.tsx
@@ -11,23 +11,11 @@ import classes from './Thumbnail.module.css';
 // Maybe add some hover effects?
 // More tests need to be written once implemented in the app
 
-interface ThumbnailProps {
+interface TitleProps {
   movie: iMovie;
-  mode: 'rec' | 'trend';
 }
 
-const TrendingTitle: React.FC<{ movie: iMovie }> = ({ movie }) => {
-  return (
-    <div className={classes.titleContainer}>
-      <Link className={classes.movieTitle} to={movie.slug}>
-        {movie.title} -
-      </Link>
-      <div>{movie.year}</div>
-    </div>
-  );
-};
-
-const RecommendedTitle: React.FC<{ movie: iMovie }> = ({ movie }) => {
+const MovieTitle: React.FC<TitleProps> = ({ movie }) => {
   return (
     <div className={classes.recTitleContainer}>
       <div className={classes.firstRow}>
@@ -44,7 +32,7 @@ const RecommendedTitle: React.FC<{ movie: iMovie }> = ({ movie }) => {
   );
 };
 
-const Thumbnail: React.FC<ThumbnailProps> = ({ movie, mode }) => {
+const Thumbnail: React.FC<ThumbnailProps> = ({ movie }) => {
   const [imgSrc, setImgSrc] = useState(movie.thumbnail);
 
   const handleError = () => {
@@ -54,11 +42,7 @@ const Thumbnail: React.FC<ThumbnailProps> = ({ movie, mode }) => {
   return (
     <>
       <div className={classes.outerDiv}>
-        {mode === 'rec' ? (
-          <RecommendedTitle movie={movie} />
-        ) : (
-          <TrendingTitle movie={movie} />
-        )}
+      <MovieTitle movie={movie} />
         <Link to={movie.slug}>
           <img
             className={classes.image}

--- a/src/pages/Categories/Categories.tsx
+++ b/src/pages/Categories/Categories.tsx
@@ -118,7 +118,7 @@ export default function Categories() {
                   onClick={() => handleMovieClick(movie.slug)}
                   key={movie.id}
                 >
-                  <Thumbnail movie={movie} mode='rec' key={index} />
+                  <Thumbnail movie={movie} key={index} />
                 </div>
               ))}
             </div>

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -6,7 +6,7 @@ export default function HomePage() {
     <div className='nav-padding'>
       <h1>HomePage</h1>
       {movies.map((movie, index) => (
-        <Thumbnail movie={movie} mode='rec' key={index} />
+        <Thumbnail movie={movie} key={index} />
       ))}
     </div>
   );

--- a/src/tests/BookmarkButton.test.tsx
+++ b/src/tests/BookmarkButton.test.tsx
@@ -9,7 +9,7 @@ import FilmView from '../pages/FilmView/FilmView';
 describe('BookmarkButton', () => {
   it('should render in Thumbnails with mode "rec"', async () => {
     const movie = movies[0];
-    render(<Thumbnail movie={movie} mode='rec' />, { wrapper: MemoryRouter });
+    render(<Thumbnail movie={movie} />, { wrapper: MemoryRouter });
 
     expect(await screen.findByTestId('bookmark-button')).toBeInTheDocument();
   });
@@ -78,7 +78,7 @@ describe('BookmarkButton', () => {
 
     const user = userEvent.setup();
 
-    render(<Thumbnail movie={movie} mode='rec' />, { wrapper: MemoryRouter });
+    render(<Thumbnail movie={movie} />, { wrapper: MemoryRouter });
 
     // Double check that the movie is not in the bookmarks
     expect(

--- a/src/tests/Thumbnail.test.tsx
+++ b/src/tests/Thumbnail.test.tsx
@@ -20,11 +20,11 @@ describe('Thumbnail component', () => {
       'https://m.media-amazon.com/images/M/MV5BNDE3ODcxYzMtY2YzZC00NmNlLWJiNDMtZDViZWM2MzIxZDYwXkEyXkFqcGdeQXVyNjAwNDUxODI@._V1_QL75_UX380_CR0,4,380,562_.jpg',
   };
 
-  describe('Thumbnail component in trend mode', () => {
+  describe('Thumbnail component renders correctly', () => {
     beforeEach(() => {
       render(
         <MemoryRouter>
-          <Thumbnail movie={mockMovie} mode='trend' />
+          <Thumbnail movie={mockMovie} />
         </MemoryRouter>
       );
       image = screen.getByAltText(`${mockMovie.title} image`);
@@ -38,5 +38,9 @@ describe('Thumbnail component', () => {
       expect(image).toBeInTheDocument();
       expect(image).toHaveAttribute('src', mockMovie.thumbnail);
     });
+  });
+
+  it('renders correctly with movie data', () => {
+    expect(screen.getByText(`${mockMovie.rating} rating`)).toBeInTheDocument();
   });
 });

--- a/src/tests/Thumbnail.test.tsx
+++ b/src/tests/Thumbnail.test.tsx
@@ -39,20 +39,4 @@ describe('Thumbnail component', () => {
       expect(image).toHaveAttribute('src', mockMovie.thumbnail);
     });
   });
-
-  describe('Thumbnail component in recommended mode', () => {
-    beforeEach(() => {
-      render(
-        <MemoryRouter>
-          <Thumbnail movie={mockMovie} mode='rec' />
-        </MemoryRouter>
-      );
-    });
-
-    it('renders correctly with movie data', () => {
-      expect(
-        screen.getByText(`${mockMovie.rating} rating`)
-      ).toBeInTheDocument();
-    });
-  });
 });

--- a/src/tests/Thumbnail.test.tsx
+++ b/src/tests/Thumbnail.test.tsx
@@ -39,8 +39,4 @@ describe('Thumbnail component', () => {
       expect(image).toHaveAttribute('src', mockMovie.thumbnail);
     });
   });
-
-  it('renders correctly with movie data', () => {
-    expect(screen.getByText(`${mockMovie.rating} rating`)).toBeInTheDocument();
-  });
 });


### PR DESCRIPTION
## Länkat issue
[Issue](https://github.com/JNMTFFED22G/Filmflix/issues/36)

## Problem / Mål
Hade 2st olika utseende beroende om det var rekomenderade eller trendande filmer. Detta behövs ej, då dom skall visa samma data.

## Utredning
Tog bort två funktioner som gjorde nästan samma sak, den ena saknade .rating, Utseendet ändrades av en prop "mode" som också togs bort då den inte används mer.

Till exempel:
Knappar bör läggas in som ```<Button></Button>```

## Lösning / Implementation
Tog bort två funktioner som gjorde nästan samma sak, den ena saknade .rating. Lade till en funktion bara istället och låter MovieCarousel sköta vad som skall renderas i ThumbNail. Utseendet ändrades av en prop "mode" som också togs bort då den inte används mer.

## Testning
Tog bort ett test för "mode" prop.
